### PR TITLE
chore: 🤖 .coderabbit.yaml を本格運用向けに拡充

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,3 +1,80 @@
-language: "ja"
+# CodeRabbit configuration
+# https://docs.coderabbit.ai/reference/configuration
+
+language: 'ja-JP'
+early_access: false
+enable_free_tier: true
+
 reviews:
+  # Nuxt.js で構築されたフロントエンドアプリを管理する公開リポジトリのため、XSS / 認可不足 / 秘密情報の混入を取りこぼしたくない。
+  # "assertive" で検出感度を高めに保ち、ノイズが過剰になった場合は "chill" に戻すことも検討する。
+  profile: 'assertive'
+
+  # PR 全体に対する指針。path_instructions に "**/*" を入れるとファイル毎に
+  # 繰り返し適用されてノイズが増えるため、広範な指示は instructions に集約する。
+  instructions: |
+    変更がプロジェクト全体に与える影響や、アーキテクチャの観点など、広いスコープからコードレビューを行ってください。必ず日本語でコメントしてください。
+    公開リポジトリで管理される Web アプリ／フロントエンドである点を考慮し、以下の観点を強調し、重要視して必ずレビューに盛り込んでください:
+    - 認証情報、API キー、トークン、内部 URL などの秘密情報がコード・ログ・ビルド成果物に混入していないこと。
+    - XSS / CSRF / SQL インジェクション / 認可不足 / パストラバーサルなどユーザーに害を与え得る脆弱性が無いこと。
+    - 外部入力 (URL / フォーム / API リクエスト) のバリデーションが抜けていないこと。
+
+  # CodeRabbit を bot reviewer として動作させる。問題なしと判断した PR に対して
+  # Approve ステータスを返す。個人運営での self-merge 運用 (PR 作成者は自分の
+  # PR を承認できない GitHub 仕様) を補助する目的で有効化。Approve は最終判断
+  # ではなく補助。
+  request_changes_workflow: true
+
+  high_level_summary: true
   poem: false
+  review_status: true
+  collapse_walkthrough: true
+
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - main
+
+  path_instructions:
+    - path: '**/*.{vue,js,ts}'
+      instructions: |
+        Nuxt.js / Vue 構成のフロントエンドコードとしてレビューしてください:
+        - コンポーネント設計や Props / Events 定義が適切か。
+        - ユーザー入力のバリデーションや XSS 対策 (`v-html` / `innerHTML` の直接使用) に不備が無いか。
+        - 認証状態に依存する画面遷移・データ取得が SSR/CSR 境界で正しく扱われているか。
+    - path: '.github/workflows/**'
+      instructions: |
+        GitHub Actions ワークフローとしてレビューしてください:
+        - シークレットの露出 (echo / set-output 経由のリーク) が無いか。
+        - 外部 action は SHA pin されているか。
+        - permissions: が最小権限になっているか。
+
+  # 生成物 / 依存物 / ロックファイルなどはレビュー対象から除外する。
+  path_filters:
+    - '!**/dist/**'
+    - '!**/build/**'
+    - '!**/coverage/**'
+    - '!**/node_modules/**'
+    - '!**/.wrangler/**'
+    - '!**/.turbo/**'
+    - '!**/.next/**'
+    - '!infra/cdktf.out/**'
+    - '!infra/.gen/**'
+    - '!**/bun.lock'
+    - '!**/package-lock.json'
+    - '!**/yarn.lock'
+    - '!**/pnpm-lock.yaml'
+    - '!**/*.min.js'
+    - '!**/*.min.css'
+    - '!**/*.map'
+    - '!**/*.snap'
+    - '!**/*.tsbuildinfo'
+
+  abort_on_close: true
+
+chat:
+  auto_reply: true
+
+knowledge_base:
+  opt_out: false

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,14 +1,14 @@
 # CodeRabbit configuration
 # https://docs.coderabbit.ai/reference/configuration
 
-language: 'ja-JP'
+language: "ja-JP"
 early_access: false
 enable_free_tier: true
 
 reviews:
   # Nuxt.js で構築されたフロントエンドアプリを管理する公開リポジトリのため、XSS / 認可不足 / 秘密情報の混入を取りこぼしたくない。
   # "assertive" で検出感度を高めに保ち、ノイズが過剰になった場合は "chill" に戻すことも検討する。
-  profile: 'assertive'
+  profile: "assertive"
 
   # PR 全体に対する指針。path_instructions に "**/*" を入れるとファイル毎に
   # 繰り返し適用されてノイズが増えるため、広範な指示は instructions に集約する。
@@ -37,13 +37,13 @@ reviews:
       - main
 
   path_instructions:
-    - path: '**/*.{vue,js,ts}'
+    - path: "**/*.{vue,js,ts}"
       instructions: |
         Nuxt.js / Vue 構成のフロントエンドコードとしてレビューしてください:
         - コンポーネント設計や Props / Events 定義が適切か。
         - ユーザー入力のバリデーションや XSS 対策 (`v-html` / `innerHTML` の直接使用) に不備が無いか。
         - 認証状態に依存する画面遷移・データ取得が SSR/CSR 境界で正しく扱われているか。
-    - path: '.github/workflows/**'
+    - path: ".github/workflows/**"
       instructions: |
         GitHub Actions ワークフローとしてレビューしてください:
         - シークレットの露出 (echo / set-output 経由のリーク) が無いか。
@@ -52,24 +52,24 @@ reviews:
 
   # 生成物 / 依存物 / ロックファイルなどはレビュー対象から除外する。
   path_filters:
-    - '!**/dist/**'
-    - '!**/build/**'
-    - '!**/coverage/**'
-    - '!**/node_modules/**'
-    - '!**/.wrangler/**'
-    - '!**/.turbo/**'
-    - '!**/.next/**'
-    - '!infra/cdktf.out/**'
-    - '!infra/.gen/**'
-    - '!**/bun.lock'
-    - '!**/package-lock.json'
-    - '!**/yarn.lock'
-    - '!**/pnpm-lock.yaml'
-    - '!**/*.min.js'
-    - '!**/*.min.css'
-    - '!**/*.map'
-    - '!**/*.snap'
-    - '!**/*.tsbuildinfo'
+    - "**/dist/**"
+    - "**/build/**"
+    - "**/coverage/**"
+    - "**/node_modules/**"
+    - "**/.wrangler/**"
+    - "**/.turbo/**"
+    - "**/.next/**"
+    - "infra/cdktf.out/**"
+    - "infra/.gen/**"
+    - "**/bun.lock"
+    - "**/package-lock.json"
+    - "**/yarn.lock"
+    - "**/pnpm-lock.yaml"
+    - "**/*.min.js"
+    - "**/*.min.css"
+    - "**/*.map"
+    - "**/*.snap"
+    - "**/*.tsbuildinfo"
 
   abort_on_close: true
 


### PR DESCRIPTION
## Summary

- CodeRabbit のレビュー指針 (`instructions`) を本リポジトリの性質に合わせて拡充
- `request_changes_workflow: true` を有効化し、問題なしと判断された PR に対する bot Approve を有効化（self-merge 運用の補助）
- `profile: 'assertive'` で検出感度を高めに固定
- `path_instructions` をリポジトリのスタックに合わせて整理（Dockerfile / Shell / Web / その他言語ごとの観点）
- `path_filters` で生成物・ロックファイル等のノイズを除外
- monopo / hyakuninissyu / toique と同じ運用ポリシーに揃え、個人運営リポジトリ間の設定差異を解消

## Test plan

- [ ] CodeRabbit が本 PR 自体に対して新ポリシーで自動レビューを行うこと
- [ ] 問題なしと判断された場合に CodeRabbit が Approve コメントを付与すること