### PR TITLE
fix: @tootallnate/once の推移依存を overrides で 2.0.1 に統一

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23323,16 +23323,6 @@
         "node": ">= 10.12.0"
       }
     },
-    "node_modules/node-gyp/node_modules/@tootallnate/once": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/node-gyp/node_modules/http-proxy-agent": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "vue-prismjs": "^1.2.0"
   },
   "overrides": {
-    "tar": "7.5.11"
+    "tar": "7.5.11",
+    "@tootallnate/once": "2.0.1"
   },
   "devDependencies": {
     "@vue/test-utils": "^1.0.0-beta.27",


### PR DESCRIPTION
## Summary

- Dependabot の security update が `security_update_not_possible` で失敗していたため、`package.json` の `overrides` に `@tootallnate/once: 2.0.1` を追加し、`node-sass@9.0.0` 経由で `http-proxy-agent@4.0.1` にネストされていた `@tootallnate/once@1.x` を統一する
- `@tootallnate/once@1.x` の既知脆弱性 (GHSA-px4h-xg32-q955 = ReDoS) を解消

## 背景

- 失敗していた Dependabot ジョブ: https://github.com/genzouw/dice-api/actions/runs/26494308507/job/78018735517
- `Dependabot encountered '1' error(s)` / `security_update_not_possible` で終了
  - `latest-resolvable-version`: `1.1.2`
  - `lowest-non-vulnerable-version`: `2.0.1`
  - 衝突箇所:
    - `node-sass@9.0.0` → `http-proxy-agent@4.0.1` → `@tootallnate/once@1`
- 推移依存を Dependabot 単独で `2.x` 系へ持ち上げる解決パスを見つけられず失敗していた
- PR #19 (`tar`) と同じ overrides 手法を `@tootallnate/once` にも適用

## 変更内容

- `package.json` の `overrides` に `@tootallnate/once: 2.0.1` を追加
- `npm install --package-lock-only --legacy-peer-deps` で `package-lock.json` を再生成
  - `node_modules/@tootallnate/once` が `2.0.1` に統一されることを確認
  - `npm audit` で `@tootallnate/once` の脆弱性が解消されることを確認

## メジャーバージョン更新に関する注意

`@tootallnate/once@1` → `@tootallnate/once@2` はメジャーバージョン更新ですが、本パッケージは Promise を 1 回だけ resolve する小さなユーティリティで、v2 の主な変更は **Node.js < 10 サポート打ち切り** と **TypeScript 型定義の追加** です。Node.js >=20 を要求する本プロジェクトでは互換性の問題は発生しない想定です。

## Test plan

- [x] `npm install --package-lock-only --legacy-peer-deps` で lockfile を再生成し、`node_modules/@tootallnate/once` が `2.0.1` 単一エントリに統一されることを確認
- [x] `npm audit` の出力に `@tootallnate/once` の脆弱性が含まれないことを確認
- [ ] ローカルで `npm ci --legacy-peer-deps && npm run build` を実行してビルドが成功すること
- [ ] Dependabot による security alert (#1385935334) が解消すること