### PR TITLE
fix: devalue の推移依存を overrides で 5.8.1 に統一

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12310,9 +12310,9 @@
       }
     },
     "node_modules/devalue": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-2.0.1.tgz",
-      "integrity": "sha512-I2TiqT5iWBEyB8GRfTDP0hiLZ0YeDJZ+upDxjBfOC2lebO5LezQMv7QvIUTzdb64jQyAKLf1AHADtGN+jw6v8Q==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
+      "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
       "license": "MIT"
     },
     "node_modules/diffie-hellman": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   "overrides": {
     "tar": "7.5.11",
     "@tootallnate/once": "2.0.1",
-    "serialize-javascript": "7.0.5"
+    "serialize-javascript": "7.0.5",
+    "devalue": "5.8.1"
   },
   "devDependencies": {
     "@vue/test-utils": "^1.0.0-beta.27",


### PR DESCRIPTION
## Summary

- Dependabot の security update が `security_update_not_possible` で失敗していたため、`package.json` の `overrides` に `devalue: 5.8.1` を追加し、`nuxt@2.18.1` 経由で `@nuxt/generator@2.18.1` にネストされていた `devalue@2.x` を統一する
- `devalue@<5.8.1` の既知脆弱性 (GHSA-9p95-fxvg-qgq2 等、prototype pollution / XSS) を解消

## 背景

- 失敗していた Dependabot ジョブ: https://github.com/genzouw/dice-api/actions/runs/26495509428/job/78022675736
- `Dependabot encountered '1' error(s)` / `security_update_not_possible` で終了
  - `latest-resolvable-version`: `2.0.1`
  - `lowest-non-vulnerable-version`: `5.8.1`
  - 衝突箇所: `nuxt@2.18.1` → `@nuxt/generator@2.18.1` → `devalue@^2.0.1`
- 推移依存を Dependabot 単独で `5.x` 系へ持ち上げる解決パスを見つけられず失敗していた
- PR #19 / #20 / #21 と同じ overrides 手法を `devalue` にも適用

## 変更内容

- `package.json` の `overrides` に `devalue: 5.8.1` を追加
- `npm install --package-lock-only --legacy-peer-deps` で `package-lock.json` を再生成
  - `node_modules/devalue` が `5.8.1` 単一エントリに統一されることを確認
  - `node_modules/@nuxt/devalue` (`2.0.2`) は別パッケージのため影響なし
  - `npm audit` で `devalue` の脆弱性が解消されることを確認

## ⚠️ 注意（破壊的変更の可能性）

`devalue@2` → `devalue@5` は API に破壊的変更を含むメジャーバージョン更新です:
- `devalue@2`: `devalue(value)` がデフォルトエクスポートで文字列を返す
- `devalue@3+`: `stringify` / `parse` / `unflatten` 等の named export 形式に分割

Nuxt 2 の SSR データシリアライズ (`@nuxt/generator` 経由) が `devalue@5` で正しく動作するかは、本 PR の変更だけでは保証されません。マージ前に `npm run build` および `npm run generate` の動作確認を推奨します。

## Test plan

- [x] `npm install --package-lock-only --legacy-peer-deps` で lockfile を再生成し、`node_modules/devalue` が `5.8.1` 単一エントリに統一されることを確認
- [x] `npm audit` の出力に `devalue` の脆弱性が含まれないことを確認
- [ ] ローカルで `npm ci --legacy-peer-deps && npm run build && npm run generate` を実行してビルドが成功すること
- [ ] Dependabot による security alert (#1385971985) が解消すること