### PR TITLE
fix: defu の推移依存を overrides で 6.1.7 に統一

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7453,12 +7453,6 @@
         "serve-static": "^1.14.1"
       }
     },
-    "node_modules/@nuxt/loading-screen/node_modules/defu": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-5.0.1.tgz",
-      "integrity": "sha512-EPS1carKg+dkEVy3qNTqIdp2qV7mUP08nIsupfwQpz++slCVRw7qbQyWvSTig+kFPwz2XXp5/kIIkH+CwrJKkQ==",
-      "license": "MIT"
-    },
     "node_modules/@nuxt/opencollective": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@nuxt/opencollective/-/opencollective-0.3.3.tgz",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "serialize-javascript": "7.0.5",
     "devalue": "5.8.1",
     "micromatch": "4.0.8",
-    "braces": "3.0.3"
+    "braces": "3.0.3",
+    "defu": "6.1.7"
   },
   "devDependencies": {
     "@vue/test-utils": "^1.0.0-beta.27",


### PR DESCRIPTION
## Summary

- Dependabot の security update が `security_update_not_possible` で失敗していたため、`package.json` の `overrides` に `defu: 6.1.7` を追加し、`nuxt@2.18.1` 経由で `@nuxt/loading-screen@2.0.4` にネストされていた `defu@5.0.1` を統一する
- `defu@<6.1.5` の既知脆弱性 (prototype pollution) を解消

## 背景

- 失敗していた Dependabot ジョブ: https://github.com/genzouw/dice-api/actions/runs/26497686457/job/78029837765
- `Dependabot encountered '1' error(s)` / `security_update_not_possible` で終了
  - `latest-resolvable-version`: `5.0.1`
  - `lowest-non-vulnerable-version`: `6.1.5`
  - 衝突箇所: `nuxt@2.18.1` → `@nuxt/loading-screen@2.0.4` → `defu@^5.0.0`
- 修正前の lockfile には以下のネスト版が存在:
  - `node_modules/@nuxt/loading-screen/node_modules/defu` → `5.0.1` (脆弱)
  - `node_modules/defu` → `6.1.7`
- 推移依存を Dependabot 単独で `6.x` 系へ持ち上げる解決パスを見つけられず失敗していた
- PR #19 / #20 / #21 / #22 / #24 / #27 と同じ overrides 手法を `defu` にも適用

## 変更内容

- `package.json` の `overrides` に `defu: 6.1.7` を追加
- `npm install --package-lock-only --legacy-peer-deps` で `package-lock.json` を再生成
  - `node_modules/defu` が `6.1.7` 単一エントリに統一されることを確認
  - `npm audit` で `defu` の脆弱性が解消されることを確認

## メジャーバージョン更新に関する注意

`defu@5` → `defu@6` はメジャーバージョン更新ですが、主な変更は **Node.js >= 14 要件化** と **ESM サポート強化** で、公開 API (`defu(...sources)` 等) は後方互換性が維持されています。Node.js >=20 を要求する本プロジェクトでは互換性の問題は発生しない想定です。

## Test plan

- [x] `npm install --package-lock-only --legacy-peer-deps` で lockfile を再生成し、`node_modules/defu` が `6.1.7` 単一エントリに統一されることを確認
- [x] `npm audit` の出力に `defu` の脆弱性が含まれないことを確認
- [ ] ローカルで `npm ci --legacy-peer-deps && npm run build && npm run generate` を実行してビルドが成功すること
- [ ] Dependabot による security alert (#1386026032) が解消すること

## 関連

- 本問題の恒久対策である Nuxt 2 → Nuxt 3 移行は #25 で追跡中