### PR TITLE
refactor: 💡 [Issue #41] @nuxt/eslint モジュールへの移行

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,4 +1,4 @@
-import withNuxt from './.nuxt/eslint.config.mjs';
-import eslintPluginPrettierRecommended from 'eslint-plugin-prettier/recommended';
+import withNuxt from "./.nuxt/eslint.config.mjs";
+import eslintPluginPrettierRecommended from "eslint-plugin-prettier/recommended";
 
-export default withNuxt().append(eslintPluginPrettierRecommended);
+export default withNuxt(eslintPluginPrettierRecommended);

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,4 +1,4 @@
-import { createConfigForNuxt } from "@nuxt/eslint-config/flat";
-import eslintPluginPrettierRecommended from "eslint-plugin-prettier/recommended";
+import withNuxt from './.nuxt/eslint.config.mjs';
+import eslintPluginPrettierRecommended from 'eslint-plugin-prettier/recommended';
 
-export default createConfigForNuxt({}).append(eslintPluginPrettierRecommended);
+export default withNuxt().append(eslintPluginPrettierRecommended);

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,6 +1,6 @@
 export default defineNuxtConfig({
   compatibilityDate: '2026-05-27',
-  modules: ['bootstrap-vue-next/nuxt', '@nuxtjs/gtag'],
+  modules: ['@nuxt/eslint', 'bootstrap-vue-next/nuxt', '@nuxtjs/gtag'],
   css: ['bootstrap/dist/css/bootstrap.min.css', 'prismjs/themes/prism.css'],
   gtag: {
     id: 'G-XXXXXXXXXX',

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@nuxt/test-utils": "^3.0.0",
     "@vue/test-utils": "^2.0.0",
-    "@nuxt/eslint-config": "^1.0.0",
+    "@nuxt/eslint": "^1.15.2",
     "eslint": "10.4.0",
     "eslint-plugin-prettier": "5.5.5",
     "eslint-plugin-vue": "10.9.1",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "generate": "nuxt generate",
     "preview": "nuxt preview",
     "test": "vitest run",
-    "lint": "eslint ."
+    "lint": "nuxi prepare && eslint ."
   },
   "dependencies": {
     "@nuxtjs/gtag": "^3.0.0",


### PR DESCRIPTION
## Summary

- `@nuxt/eslint-config`（手動 Flat Config セットアップ）を公式 `@nuxt/eslint` Nuxt モジュールに置き換え
- `nuxt.config.ts` の `modules` に `@nuxt/eslint` を追加し、Nuxt のビルド時統合・auto-imports 対応を有効化
- `eslint.config.mjs` を `withNuxt()` 形式に更新（生成された `.nuxt/eslint.config.mjs` を参照）
- Prettier 統合（`eslint-plugin-prettier`）は引き続き維持

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `package.json` | `@nuxt/eslint-config` → `@nuxt/eslint ^1.15.2` に置き換え |
| `nuxt.config.ts` | `modules` に `'@nuxt/eslint'` を追加 |
| `eslint.config.mjs` | `createConfigForNuxt()` → `withNuxt()` 形式に更新 |

## 背景

PR #40 で `@nuxt/eslint-config` の手動設定を導入しましたが、Codacy のコードレビューにて、Nuxt のビルド時最適化・auto-imports との統合がより優れた公式 `@nuxt/eslint` モジュールへの移行が推奨されました（Issue #41）。

## Test plan

- [ ] `npm install` でパッケージが正常インストールされること
- [ ] `nuxt prepare` で `.nuxt/eslint.config.mjs` が生成されること
- [ ] `npm run lint` でESLintが実行され、既存コードにエラーが出ないこと
- [ ] `defineNuxtConfig`、`defineEventHandler` 等のauto-importsがESLintエラーにならないこと

Closes #41